### PR TITLE
Fix: Modify daily puzzle letter selection for balanced hands

### DIFF
--- a/script.js
+++ b/script.js
@@ -299,12 +299,21 @@ document.addEventListener('DOMContentLoaded', () => {
     
     letterPool = tempPool; // Assign to global letterPool
 
-    const selectedLetters = letterPool.slice(0, NUM_TILES); // Get the first NUM_TILES for the player's hand
+    const handLetters = [];
+    for (let i = 0; i < NUM_TILES; i++) {
+      if (letterPool.length === 0) {
+        console.warn("Letter pool exhausted while generating daily hand.");
+        break;
+      }
+      const pluckIndex = Math.floor(getNextRandom() * letterPool.length);
+      const letter = letterPool.splice(pluckIndex, 1)[0];
+      handLetters.push(letter);
+    }
 
     if(!tileContainer) return;
     tileContainer.innerHTML = ''; 
 
-    selectedLetters.forEach((letter, i) => {
+    handLetters.forEach((letter, i) => {
       if (!letter) return; 
       const tile = document.createElement('div');
       tile.classList.add('letter-tile');


### PR DESCRIPTION
The daily puzzle's initial hand generation was taking a direct slice of the first 16 tiles from the deterministically shuffled full letter pool. This could lead to skewed vowel/consonant ratios if the seeded shuffle resulted in an uneven distribution at the beginning of the pool.

This commit changes the `generateDailyTiles` function to select its initial 16 tiles by repeatedly using the seeded RNG (`getNextRandom()`) to pick an index and `splice` a tile from the `letterPool`. This method simulates a series of deterministic "random" draws for the hand, making it less susceptible to an uneven distribution at the start of the shuffled list.

The global `letterPool` for the daily game is now also correctly updated, as `splice` removes the tiles directly, ensuring that subsequent operations like tile exchanges draw from the correct remaining set of letters. This approach aligns the daily puzzle's hand generation more closely with the effective randomness of the regular game's `pop` mechanism and the existing daily game's exchange mechanism.